### PR TITLE
feat: deploy approval gates via GitHub Environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,6 +44,7 @@ jobs:
   deploy-production:
     needs: verify-staging
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,16 +1,15 @@
 name: Deploy Staging
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   deploy-staging:
-    if: "!contains(github.event.head_commit.message, '[version-bump]')"
     runs-on: ubuntu-latest
+    environment: staging
     steps:
       - uses: actions/checkout@v6
         with:

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,54 @@
+# Deploy Process
+
+All deployments require explicit board approval via GitHub Environment protection rules.
+
+## Workflow
+
+```
+Code change → PR → CI checks → Merge to main → CI runs on main
+                                                      ↓
+                                        Manual trigger: Deploy Staging
+                                        (requires board approval via GitHub Environment)
+                                                      ↓
+                                        Manual trigger: Deploy Production
+                                        (requires board approval via GitHub Environment)
+```
+
+## Environments
+
+| Environment | Workflow | Trigger | Approval |
+|-------------|----------|---------|----------|
+| **Staging** | `deploy-staging.yml` | `workflow_dispatch` (manual) | GitHub Environment `staging` — board reviewer required |
+| **Production** | `deploy-production.yml` | `workflow_dispatch` (manual) | GitHub Environment `production` — board reviewer required |
+
+## How to Deploy
+
+### 1. Staging
+
+1. Go to **Actions → Deploy Staging → Run workflow** on the `main` branch.
+2. A board member with Environment reviewer access must approve the pending deployment.
+3. Once approved, the workflow runs: install → prisma → typecheck → test → build → deploy to Cloudflare Workers (staging).
+
+### 2. Production
+
+1. Go to **Actions → Deploy Production → Run workflow**.
+2. The workflow first verifies a recent successful staging deployment exists.
+3. A board member must approve the pending deployment via the `production` Environment gate.
+4. Once approved: install → prisma → typecheck → test → build → deploy to Cloudflare Workers (production).
+
+## CI (Automatic)
+
+- **On push to `main`**: `ci.yml` runs typecheck + tests (no deploy).
+- **On pull request to `main`**: `ci.yml` runs typecheck + tests.
+
+## Branch Protection (Required)
+
+`main` branch should have:
+- Require pull request before merging (at least 1 approval)
+- Require status checks to pass (CI workflow)
+
+## Prerequisites
+
+A repo admin must configure:
+1. GitHub Environments `staging` and `production` with required reviewers (board members)
+2. Branch protection rules on `main`


### PR DESCRIPTION
## Summary

- **deploy-staging.yml**: Changed from auto-deploy on push to `main` → manual `workflow_dispatch` with `environment: staging` gate requiring board approval
- **deploy-production.yml**: Added `environment: production` gate requiring board approval before deploy executes
- **ci.yml**: Extended to run on push to `main` (so merges still get CI feedback without triggering a deploy)
- **docs/DEPLOY.md**: Documents the new deploy process, environment setup, and board approval workflow

## Prerequisites (board action required)

- [ ] Create `staging` GitHub Environment with required reviewers (board members)
- [ ] Create `production` GitHub Environment with required reviewers (board members)
- [ ] Enable branch protection on `main` (require PR + 1 approval + status checks)

## Test plan

- [ ] Verify CI runs on PR and on push to main
- [ ] Verify staging deploy requires manual trigger + environment approval
- [ ] Verify production deploy requires manual trigger + environment approval
- [ ] Confirm no auto-deploy occurs on push to main

Resolves POD-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)