### PR TITLE
feat: listen-original schema aligned with POD-87 plan

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1070,6 +1070,7 @@ enum ListenOriginalEventType {
   listen_original_click
   listen_original_start
   listen_original_complete
+  listen_original_return
 }
 
 enum DeviceType {
@@ -1092,9 +1093,11 @@ enum ReferralSource {
 }
 
 model ListenOriginalEvent {
-  id                    String                   @id @default(cuid())
+  id                    String                   @id @default(uuid())
+  idempotencyKey        String                   @unique
   eventType             ListenOriginalEventType
-  timestamp             DateTime                 @default(now())
+  timestamp             DateTime
+  receivedAt            DateTime                 @default(now())
   userId                String
   sessionId             String
   deviceType            DeviceType
@@ -1107,21 +1110,18 @@ model ListenOriginalEvent {
   referralSource        ReferralSource
   timeToClickSec        Float
   blippCompletionPct    Float
-  didReturnToBlipp      Boolean                  @default(false)
   utmSource             String?
   utmMedium             String?
   utmCampaign           String?
-  reportBatchId         String?
   createdAt             DateTime                 @default(now())
 
   user    User    @relation("ListenOriginalEvents", fields: [userId], references: [id], onDelete: Cascade)
   episode Episode @relation("ListenOriginalEvents", fields: [episodeId], references: [id], onDelete: Cascade)
 
-  @@index([publisherId, timestamp])
-  @@index([userId, timestamp])
+  @@index([publisherId, receivedAt])
+  @@index([userId, receivedAt])
   @@index([blippId, eventType])
-  @@index([episodeId, timestamp])
-  @@index([reportBatchId])
+  @@index([episodeId, receivedAt])
 }
 
 model PublisherReportBatch {
@@ -1133,6 +1133,7 @@ model PublisherReportBatch {
   totalStarts    Int
   totalCompletes Int
   uniqueUsers    Int
+  clickThroughRate Float?
   generatedAt    DateTime @default(now())
 
   @@index([publisherId, periodStart])

--- a/worker/lib/cron/listen-original-aggregation.ts
+++ b/worker/lib/cron/listen-original-aggregation.ts
@@ -3,7 +3,6 @@ import type { CronLogger } from "./runner";
 type PrismaLike = {
   listenOriginalEvent: {
     groupBy: (args: any) => Promise<any[]>;
-    updateMany: (args: any) => Promise<{ count: number }>;
     count: (args: any) => Promise<number>;
   };
   publisherReportBatch: {
@@ -13,90 +12,67 @@ type PrismaLike = {
 
 /**
  * Daily aggregation job: groups listen-original events by publisher for the
- * previous day, creates PublisherReportBatch rows, and stamps events with
- * the batch ID.
+ * previous day and creates PublisherReportBatch rows.
+ *
+ * Events are immutable — no stamping. Reports filter by receivedAt range.
+ * clickThroughRate is null until blipp impression tracking exists (see POD-96).
  */
 export async function runListenOriginalAggregationJob(
   prisma: PrismaLike,
-  logger: CronLogger
+  logger: CronLogger,
 ): Promise<Record<string, unknown>> {
   const now = new Date();
   const periodEnd = new Date(now);
-  periodEnd.setUTCHours(0, 0, 0, 0); // start of today = end of yesterday
+  periodEnd.setUTCHours(0, 0, 0, 0);
   const periodStart = new Date(periodEnd);
-  periodStart.setUTCDate(periodStart.getUTCDate() - 1); // start of yesterday
+  periodStart.setUTCDate(periodStart.getUTCDate() - 1);
 
   await logger.info("Starting listen-original aggregation", {
     periodStart: periodStart.toISOString(),
     periodEnd: periodEnd.toISOString(),
   });
 
-  // Check if there are any events to aggregate
-  const totalEvents = await prisma.listenOriginalEvent.count({
-    where: {
-      timestamp: { gte: periodStart, lt: periodEnd },
-      reportBatchId: null,
-    },
-  });
-
-  if (totalEvents === 0) {
-    await logger.info("No unbatched events for period, skipping");
-    return { batchesCreated: 0, eventsProcessed: 0 };
-  }
-
-  // Group by publisher
+  // Group by publisher for the period
   const publisherGroups = await prisma.listenOriginalEvent.groupBy({
     by: ["publisherId"],
     where: {
-      timestamp: { gte: periodStart, lt: periodEnd },
-      reportBatchId: null,
+      receivedAt: { gte: periodStart, lt: periodEnd },
     },
     _count: { id: true },
   });
 
+  if (publisherGroups.length === 0) {
+    await logger.info("No events for period, skipping");
+    return { batchesCreated: 0, eventsProcessed: 0 };
+  }
+
   let batchesCreated = 0;
-  let eventsStamped = 0;
+  let totalEventsProcessed = 0;
 
   for (const group of publisherGroups) {
     const publisherId = group.publisherId;
+    const periodFilter = {
+      publisherId,
+      receivedAt: { gte: periodStart, lt: periodEnd },
+    };
 
-    // Count by event type
     const [clicks, starts, completes, uniqueUserRows] = await Promise.all([
       prisma.listenOriginalEvent.count({
-        where: {
-          publisherId,
-          eventType: "listen_original_click",
-          timestamp: { gte: periodStart, lt: periodEnd },
-          reportBatchId: null,
-        },
+        where: { ...periodFilter, eventType: "listen_original_click" },
       }),
       prisma.listenOriginalEvent.count({
-        where: {
-          publisherId,
-          eventType: "listen_original_start",
-          timestamp: { gte: periodStart, lt: periodEnd },
-          reportBatchId: null,
-        },
+        where: { ...periodFilter, eventType: "listen_original_start" },
       }),
       prisma.listenOriginalEvent.count({
-        where: {
-          publisherId,
-          eventType: "listen_original_complete",
-          timestamp: { gte: periodStart, lt: periodEnd },
-          reportBatchId: null,
-        },
+        where: { ...periodFilter, eventType: "listen_original_complete" },
       }),
       prisma.listenOriginalEvent.groupBy({
         by: ["userId"],
-        where: {
-          publisherId,
-          timestamp: { gte: periodStart, lt: periodEnd },
-          reportBatchId: null,
-        },
+        where: periodFilter,
       }),
     ]);
 
-    const batch = await prisma.publisherReportBatch.create({
+    await prisma.publisherReportBatch.create({
       data: {
         publisherId,
         periodStart,
@@ -105,32 +81,21 @@ export async function runListenOriginalAggregationJob(
         totalStarts: starts,
         totalCompletes: completes,
         uniqueUsers: uniqueUserRows.length,
+        clickThroughRate: null, // No impression data yet (POD-96)
       },
     });
 
-    // Stamp events with batch ID
-    const updated = await prisma.listenOriginalEvent.updateMany({
-      where: {
-        publisherId,
-        timestamp: { gte: periodStart, lt: periodEnd },
-        reportBatchId: null,
-      },
-      data: { reportBatchId: batch.id },
-    });
-
-    eventsStamped += updated.count;
+    totalEventsProcessed += group._count.id;
     batchesCreated++;
 
     await logger.info(`Batch created for publisher ${publisherId}`, {
-      batchId: batch.id,
       clicks,
       starts,
       completes,
       uniqueUsers: uniqueUserRows.length,
-      eventsStamped: updated.count,
     });
   }
 
-  await logger.info("Aggregation complete", { batchesCreated, eventsStamped });
-  return { batchesCreated, eventsProcessed: eventsStamped };
+  await logger.info("Aggregation complete", { batchesCreated, totalEventsProcessed });
+  return { batchesCreated, eventsProcessed: totalEventsProcessed };
 }

--- a/worker/routes/admin/publisher-reports.ts
+++ b/worker/routes/admin/publisher-reports.ts
@@ -37,10 +37,13 @@ publisherReportsRoutes.get("/:batchId", async (c) => {
     return c.json({ error: "Batch not found" }, 404);
   }
 
-  // Get top blipps by conversion for this batch
+  // Get top blipps by conversion for this batch period
   const topBlipps = await prisma.listenOriginalEvent.groupBy({
     by: ["blippId"],
-    where: { reportBatchId: batchId },
+    where: {
+      publisherId: batch.publisherId,
+      receivedAt: { gte: batch.periodStart, lt: batch.periodEnd },
+    },
     _count: { id: true },
     _avg: { timeToClickSec: true, blippCompletionPct: true },
     orderBy: { _count: { id: "desc" } },

--- a/worker/routes/events.ts
+++ b/worker/routes/events.ts
@@ -8,19 +8,20 @@ import { validateBody } from "../lib/validation";
 const events = new Hono<{ Bindings: Env }>();
 
 const listenOriginalSchema = z.object({
+  idempotencyKey: z.string().uuid(),
   eventType: z.enum([
     "listen_original_click",
     "listen_original_start",
     "listen_original_complete",
+    "listen_original_return",
   ]),
+  timestamp: z.string().datetime(),
   sessionId: z.string().min(1),
   deviceType: z.enum(["mobile", "desktop", "tablet"]),
   platform: z.enum(["ios", "android", "web"]),
   blippId: z.string().min(1),
   blippDurationMs: z.number().int().min(0),
   episodeId: z.string().min(1),
-  podcastId: z.string().min(1),
-  publisherId: z.string().min(1),
   referralSource: z.enum(["feed", "search", "share", "notification"]),
   timeToClickSec: z.number().min(0),
   blippCompletionPct: z.number().min(0).max(1),
@@ -29,16 +30,23 @@ const listenOriginalSchema = z.object({
   utmCampaign: z.string().optional(),
 });
 
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
 /**
  * POST /events/listen-original — Record a listen-to-original conversion event.
- * Requires authenticated user.
+ *
+ * - Validates user from auth token (never trusts client-supplied userId)
+ * - Enriches episode -> podcastId from content catalog
+ * - publisherId derived from podcast.author until Publisher model exists
+ * - Rejects timestamps >1h from server time (clock-skew guard)
+ * - UPSERTs on idempotencyKey for client retry dedup
  */
 events.post("/listen-original", requireAuth, async (c) => {
   const prisma = c.get("prisma") as any;
   const auth = getAuth(c);
   const body = await validateBody(c, listenOriginalSchema);
 
-  // Resolve internal user ID from Clerk auth
+  // Validate user from auth token
   const user = await prisma.user.findUnique({
     where: { clerkId: auth!.userId! },
     select: { id: true },
@@ -47,12 +55,38 @@ events.post("/listen-original", requireAuth, async (c) => {
     return c.json({ error: "User not found" }, 404);
   }
 
+  // Clock-skew guard: reject if client timestamp >1h from server time
+  const clientTimestamp = new Date(body.timestamp);
   const now = new Date();
+  if (Math.abs(now.getTime() - clientTimestamp.getTime()) > ONE_HOUR_MS) {
+    return c.json(
+      { error: "Timestamp rejected: differs from server time by more than 1 hour" },
+      400,
+    );
+  }
 
-  const event = await prisma.listenOriginalEvent.create({
-    data: {
+  // Enrich: look up episode -> podcast from content catalog
+  const episode = await prisma.episode.findUnique({
+    where: { id: body.episodeId },
+    select: { id: true, podcastId: true },
+  });
+  if (!episode) {
+    return c.json({ error: "Episode not found" }, 404);
+  }
+
+  // publisherId: use podcastId as proxy until Publisher model is added
+  const podcastId = episode.podcastId;
+  const publisherId = podcastId;
+
+  // UPSERT on idempotencyKey for dedup (immutable — no-op on conflict)
+  const event = await prisma.listenOriginalEvent.upsert({
+    where: { idempotencyKey: body.idempotencyKey },
+    update: {},
+    create: {
+      idempotencyKey: body.idempotencyKey,
       eventType: body.eventType,
-      timestamp: now,
+      timestamp: clientTimestamp,
+      receivedAt: now,
       userId: user.id,
       sessionId: body.sessionId,
       deviceType: body.deviceType,
@@ -60,8 +94,8 @@ events.post("/listen-original", requireAuth, async (c) => {
       blippId: body.blippId,
       blippDurationMs: body.blippDurationMs,
       episodeId: body.episodeId,
-      podcastId: body.podcastId,
-      publisherId: body.publisherId,
+      podcastId,
+      publisherId,
       referralSource: body.referralSource,
       timeToClickSec: body.timeToClickSec,
       blippCompletionPct: body.blippCompletionPct,
@@ -72,34 +106,6 @@ events.post("/listen-original", requireAuth, async (c) => {
   });
 
   return c.json({ success: true, eventId: event.id });
-});
-
-/**
- * PATCH /events/listen-original/:eventId/return — Mark that the user returned to PodBlipp.
- * Called when the user comes back after listening to the original.
- */
-events.patch("/listen-original/:eventId/return", requireAuth, async (c) => {
-  const prisma = c.get("prisma") as any;
-  const auth = getAuth(c);
-  const { eventId } = c.req.param();
-
-  const user = await prisma.user.findUnique({
-    where: { clerkId: auth!.userId! },
-    select: { id: true },
-  });
-  if (!user) {
-    return c.json({ error: "User not found" }, 404);
-  }
-
-  await prisma.listenOriginalEvent.updateMany({
-    where: {
-      id: eventId,
-      userId: user.id,
-    },
-    data: { didReturnToBlipp: true },
-  });
-
-  return c.json({ success: true });
 });
 
 export { events };


### PR DESCRIPTION
## Summary
- Aligns `ListenOriginalEvent` and `PublisherReportBatch` Prisma models with the [POD-87 plan](/POD/issues/POD-87#document-plan) Section 1
- Adds `idempotencyKey` (unique) for client retry dedup, `receivedAt` for server-side authoritative timestamp, `listen_original_return` event type
- Removes `didReturnToBlipp` mutable boolean (returns are now separate events) and `reportBatchId` FK (reports filter by timestamp range)
- Adds `clickThroughRate` to `PublisherReportBatch`

## Test plan
- [ ] `npx prisma generate` succeeds
- [ ] `npx prisma db push` against staging succeeds
- [ ] Verify indexes match plan spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)