### PR TITLE
feat: add model smoke test for AI model registry

### DIFF
--- a/src/components/admin/model-registry/model-table.tsx
+++ b/src/components/admin/model-registry/model-table.tsx
@@ -1,3 +1,4 @@
+import { useState, useCallback, useRef, useEffect } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -6,6 +7,8 @@ import {
   Trash2,
   Check,
   X,
+  Zap,
+  Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +18,8 @@ import type { AIStage } from "@/lib/ai-models";
 import type { AiModelEntry } from "@/types/admin";
 import { formatPrice, formatLimits, formatMonthlyCost } from "./helpers";
 import { AddProviderForm, EditProviderForm } from "./provider-forms";
+
+type SmokeTestState = { status: "idle" } | { status: "running" } | { status: "pass"; latencyMs: number } | { status: "fail"; error: string };
 
 export interface ModelTableProps {
   models: AiModelEntry[];
@@ -134,7 +139,7 @@ export function ModelTable({
                     <div>Pricing</div>
                     <div>Limits</div>
                     <div>Status</div>
-                    <div className="w-16 text-right">Actions</div>
+                    <div className="w-28 text-right">Actions</div>
                   </div>
 
                   {model.providers.length === 0 && (
@@ -142,67 +147,16 @@ export function ModelTable({
                   )}
 
                   {model.providers.map((prov) => (
-                    <div key={prov.id}>
-                      {editingProvider === prov.id ? (
-                        <EditProviderForm
-                          provider={prov}
-                          modelId={model.id}
-                          stage={model.stage}
-                          apiFetch={apiFetch}
-                          onDone={() => { setEditingProvider(null); onRefresh(); }}
-                          onCancel={() => setEditingProvider(null)}
-                        />
-                      ) : (
-                        <div className="grid grid-cols-[2fr_2fr_1.5fr_1fr_auto] gap-4 py-2 items-center text-xs">
-                          <div className="text-[#F9FAFB]">
-                            <div>
-                              {prov.providerLabel}
-                              <span className="ml-1.5 text-[10px] font-mono text-[#9CA3AF]">({prov.provider})</span>
-                              {prov.isDefault && (
-                                <Badge className="ml-2 text-[9px] bg-[#3B82F6]/20 text-[#3B82F6] border-0 py-0">
-                                  Default
-                                </Badge>
-                              )}
-                            </div>
-                            {prov.providerModelId && (
-                              <div className="text-[10px] font-mono text-[#6B7280] mt-0.5">{prov.providerModelId}</div>
-                            )}
-                          </div>
-                          <div className="text-[#9CA3AF] font-mono text-[11px]">{formatPrice(prov)}</div>
-                          <div className="text-[#9CA3AF] text-[11px]">{formatLimits(prov.limits)}</div>
-                          <div>
-                            <Badge
-                              variant="outline"
-                              className={`text-[10px] border-0 ${
-                                prov.isAvailable
-                                  ? "bg-[#22C55E]/10 text-[#22C55E]"
-                                  : "bg-[#EF4444]/10 text-[#EF4444]"
-                              }`}
-                            >
-                              {prov.isAvailable ? "Available" : "Unavailable"}
-                            </Badge>
-                          </div>
-                          <div className="w-16 flex justify-end gap-1">
-                            <Button
-                              variant="ghost"
-                              size="icon-xs"
-                              onClick={() => setEditingProvider(prov.id)}
-                              className="text-[#9CA3AF] hover:text-[#F9FAFB]"
-                            >
-                              <Pencil className="h-3 w-3" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon-xs"
-                              onClick={() => onDeleteProvider(model, prov.id)}
-                              className="text-[#9CA3AF] hover:text-[#EF4444]"
-                            >
-                              <Trash2 className="h-3 w-3" />
-                            </Button>
-                          </div>
-                        </div>
-                      )}
-                    </div>
+                    <ProviderRow
+                      key={prov.id}
+                      prov={prov}
+                      model={model}
+                      editingProvider={editingProvider}
+                      setEditingProvider={setEditingProvider}
+                      apiFetch={apiFetch}
+                      onDeleteProvider={onDeleteProvider}
+                      onRefresh={onRefresh}
+                    />
                   ))}
 
                   {/* Add Provider */}
@@ -231,6 +185,130 @@ export function ModelTable({
           </div>
         );
       })}
+    </div>
+  );
+}
+
+function ProviderRow({
+  prov,
+  model,
+  editingProvider,
+  setEditingProvider,
+  apiFetch,
+  onDeleteProvider,
+  onRefresh,
+}: {
+  prov: AiModelEntry["providers"][number];
+  model: AiModelEntry;
+  editingProvider: string | null;
+  setEditingProvider: (id: string | null) => void;
+  apiFetch: ReturnType<typeof useAdminFetch>;
+  onDeleteProvider: (model: AiModelEntry, providerId: string) => void;
+  onRefresh: () => void;
+}) {
+  const [testState, setTestState] = useState<SmokeTestState>({ status: "idle" });
+  const clearRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (clearRef.current) clearTimeout(clearRef.current); }, []);
+
+  const runTest = useCallback(async () => {
+    setTestState({ status: "running" });
+    try {
+      const res = await apiFetch<{ data: { success: boolean; latencyMs: number; error?: string } }>(
+        `/ai-models/${model.id}/providers/${prov.id}/smoke-test`,
+        { method: "POST" }
+      );
+      if (res.data.success) {
+        setTestState({ status: "pass", latencyMs: res.data.latencyMs });
+      } else {
+        setTestState({ status: "fail", error: res.data.error ?? "Unknown error" });
+      }
+    } catch (err) {
+      setTestState({ status: "fail", error: err instanceof Error ? err.message : "Request failed" });
+    }
+    clearRef.current = setTimeout(() => setTestState({ status: "idle" }), 10000);
+  }, [apiFetch, model.id, prov.id]);
+
+  if (editingProvider === prov.id) {
+    return (
+      <div>
+        <EditProviderForm
+          provider={prov}
+          modelId={model.id}
+          stage={model.stage}
+          apiFetch={apiFetch}
+          onDone={() => { setEditingProvider(null); onRefresh(); }}
+          onCancel={() => setEditingProvider(null)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-[2fr_2fr_1.5fr_1fr_auto] gap-4 py-2 items-center text-xs">
+      <div className="text-[#F9FAFB]">
+        <div>
+          {prov.providerLabel}
+          <span className="ml-1.5 text-[10px] font-mono text-[#9CA3AF]">({prov.provider})</span>
+          {prov.isDefault && (
+            <Badge className="ml-2 text-[9px] bg-[#3B82F6]/20 text-[#3B82F6] border-0 py-0">
+              Default
+            </Badge>
+          )}
+        </div>
+        {prov.providerModelId && (
+          <div className="text-[10px] font-mono text-[#6B7280] mt-0.5">{prov.providerModelId}</div>
+        )}
+      </div>
+      <div className="text-[#9CA3AF] font-mono text-[11px]">{formatPrice(prov)}</div>
+      <div className="text-[#9CA3AF] text-[11px]">{formatLimits(prov.limits)}</div>
+      <div>
+        <Badge
+          variant="outline"
+          className={`text-[10px] border-0 ${
+            prov.isAvailable
+              ? "bg-[#22C55E]/10 text-[#22C55E]"
+              : "bg-[#EF4444]/10 text-[#EF4444]"
+          }`}
+        >
+          {prov.isAvailable ? "Available" : "Unavailable"}
+        </Badge>
+      </div>
+      <div className="w-28 flex justify-end items-center gap-1">
+        {testState.status === "running" ? (
+          <Loader2 className="h-3 w-3 animate-spin text-[#9CA3AF]" />
+        ) : testState.status === "pass" ? (
+          <span className="text-[10px] text-[#22C55E] font-mono">{(testState.latencyMs / 1000).toFixed(1)}s</span>
+        ) : testState.status === "fail" ? (
+          <span className="text-[10px] text-[#EF4444] truncate max-w-[60px]" title={testState.error}>{testState.error}</span>
+        ) : null}
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={runTest}
+          disabled={testState.status === "running"}
+          className={`text-[#9CA3AF] hover:text-[#FBBF24] ${testState.status === "pass" ? "text-[#22C55E]" : testState.status === "fail" ? "text-[#EF4444]" : ""}`}
+          title="Smoke test"
+        >
+          <Zap className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => setEditingProvider(prov.id)}
+          className="text-[#9CA3AF] hover:text-[#F9FAFB]"
+        >
+          <Pencil className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={() => onDeleteProvider(model, prov.id)}
+          className="text-[#9CA3AF] hover:text-[#EF4444]"
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/worker/lib/__tests__/smoke-test.test.ts
+++ b/worker/lib/__tests__/smoke-test.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock provider implementations
+vi.mock("../llm-providers", () => ({
+  getLlmProviderImpl: vi.fn(),
+}));
+vi.mock("../stt/providers", () => ({
+  getProviderImpl: vi.fn(),
+}));
+vi.mock("../tts/providers", () => ({
+  getTtsProviderImpl: vi.fn(),
+}));
+
+import { runSmokeTest } from "../smoke-test";
+import { getLlmProviderImpl } from "../llm-providers";
+import { getProviderImpl } from "../stt/providers";
+import { getTtsProviderImpl } from "../tts/providers";
+
+const mockEnv = {} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("runSmokeTest", () => {
+  it("succeeds for LLM stage (distillation)", async () => {
+    const mockComplete = vi.fn().mockResolvedValue({ model: "test", inputTokens: 5, outputTokens: 3 });
+    vi.mocked(getLlmProviderImpl).mockReturnValue({ name: "test", provider: "anthropic", complete: mockComplete });
+
+    const result = await runSmokeTest("distillation", "anthropic", "claude-test", mockEnv);
+
+    expect(result.success).toBe(true);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(mockComplete).toHaveBeenCalledWith(
+      [{ role: "user", content: "Say hello." }],
+      "claude-test",
+      10,
+      mockEnv
+    );
+  });
+
+  it("succeeds for STT stage", async () => {
+    const mockTranscribe = vi.fn().mockResolvedValue({ text: "", segments: [] });
+    vi.mocked(getProviderImpl).mockReturnValue({
+      name: "test", provider: "openai", supportsUrl: false, transcribe: mockTranscribe,
+    });
+
+    const result = await runSmokeTest("stt", "openai", "whisper-1", mockEnv);
+
+    expect(result.success).toBe(true);
+    expect(mockTranscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ buffer: expect.any(ArrayBuffer), filename: "smoke-test.wav" }),
+      1,
+      mockEnv,
+      "whisper-1"
+    );
+  });
+
+  it("succeeds for TTS stage", async () => {
+    const mockSynthesize = vi.fn().mockResolvedValue({ audio: new ArrayBuffer(100), contentType: "audio/mpeg" });
+    vi.mocked(getTtsProviderImpl).mockReturnValue({ name: "test", provider: "openai", synthesize: mockSynthesize });
+
+    const result = await runSmokeTest("tts", "openai", "tts-1", mockEnv);
+
+    expect(result.success).toBe(true);
+    expect(mockSynthesize).toHaveBeenCalledWith("Hello.", "coral", "tts-1", undefined, mockEnv);
+  });
+
+  it("returns failure with actionable error on 401", async () => {
+    vi.mocked(getLlmProviderImpl).mockReturnValue({
+      name: "test", provider: "anthropic",
+      complete: vi.fn().mockRejectedValue(new Error("Request failed with status 401")),
+    });
+
+    const result = await runSmokeTest("narrative", "anthropic", "claude-test", mockEnv);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("401");
+    expect(result.error).toContain("check API key");
+  });
+
+  it("returns failure for unknown stage", async () => {
+    const result = await runSmokeTest("unknown", "openai", "model-x", mockEnv);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unknown stage");
+  });
+
+  it("returns failure when provider throws generic error", async () => {
+    vi.mocked(getTtsProviderImpl).mockReturnValue({
+      name: "test", provider: "openai",
+      synthesize: vi.fn().mockRejectedValue(new Error("Connection timeout")),
+    });
+
+    const result = await runSmokeTest("tts", "openai", "tts-1", mockEnv);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Connection timeout");
+  });
+});

--- a/worker/lib/smoke-test.ts
+++ b/worker/lib/smoke-test.ts
@@ -1,0 +1,122 @@
+import type { Env } from "../types";
+import { getLlmProviderImpl } from "./llm-providers";
+import { getProviderImpl as getSttProviderImpl } from "./stt/providers";
+import { getTtsProviderImpl } from "./tts/providers";
+
+export interface SmokeTestResult {
+  success: boolean;
+  latencyMs: number;
+  error?: string;
+  detail?: string;
+}
+
+/**
+ * Generates a minimal valid WAV file (~1s of silence at 16kHz mono 16-bit).
+ */
+function generateSilentWav(): ArrayBuffer {
+  const sampleRate = 16000;
+  const numSamples = sampleRate; // 1 second
+  const bytesPerSample = 2;
+  const dataSize = numSamples * bytesPerSample;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  // RIFF header
+  const writeStr = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+  };
+  writeStr(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true); // chunk size
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * bytesPerSample, true);
+  view.setUint16(32, bytesPerSample, true);
+  view.setUint16(34, 16, true); // bits per sample
+  writeStr(36, "data");
+  view.setUint32(40, dataSize, true);
+  // samples are all zeros (silence) by default
+
+  return buffer;
+}
+
+/**
+ * Extracts an actionable error message from a caught error.
+ */
+function extractError(err: unknown): string {
+  if (err instanceof Error) {
+    const msg = err.message;
+    // Surface HTTP status codes prominently
+    const statusMatch = msg.match(/(\d{3})/);
+    if (statusMatch) {
+      const code = parseInt(statusMatch[1]);
+      if (code === 401 || code === 403) return `${code} Unauthorized — check API key`;
+      if (code === 404) return `${code} Not Found — check model ID or endpoint`;
+      if (code === 429) return `${code} Rate Limited — try again later`;
+      if (code >= 500) return `${code} Server Error — provider issue`;
+    }
+    return msg;
+  }
+  return String(err);
+}
+
+/**
+ * Run a smoke test for a specific AI model provider.
+ * Sends a minimal request to verify the provider is reachable and configured correctly.
+ */
+export async function runSmokeTest(
+  stage: string,
+  provider: string,
+  providerModelId: string,
+  env: Env
+): Promise<SmokeTestResult> {
+  const start = Date.now();
+
+  try {
+    switch (stage) {
+      case "stt": {
+        const impl = getSttProviderImpl(provider);
+        const wav = generateSilentWav();
+        await impl.transcribe(
+          { buffer: wav, filename: "smoke-test.wav" },
+          1, // 1 second duration
+          env,
+          providerModelId
+        );
+        break;
+      }
+
+      case "distillation":
+      case "narrative": {
+        const impl = getLlmProviderImpl(provider);
+        await impl.complete(
+          [{ role: "user", content: "Say hello." }],
+          providerModelId,
+          10,
+          env
+        );
+        break;
+      }
+
+      case "tts": {
+        const impl = getTtsProviderImpl(provider);
+        await impl.synthesize("Hello.", "coral", providerModelId, undefined, env);
+        break;
+      }
+
+      default:
+        return { success: false, latencyMs: 0, error: `Unknown stage: ${stage}` };
+    }
+
+    return { success: true, latencyMs: Date.now() - start };
+  } catch (err) {
+    return {
+      success: false,
+      latencyMs: Date.now() - start,
+      error: extractError(err),
+    };
+  }
+}

--- a/worker/routes/admin/ai-models.ts
+++ b/worker/routes/admin/ai-models.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "../../types";
+import { runSmokeTest } from "../../lib/smoke-test";
 
 // Maps AiModel.stage (AiStage) to PipelineStep.stage (PipelineStage)
 const STAGE_TO_PIPELINE: Record<string, string> = {
@@ -225,6 +226,31 @@ aiModelsRoutes.delete("/:id", async (c) => {
   const id = c.req.param("id");
   await prisma.aiModel.delete({ where: { id } });
   return c.json({ success: true });
+});
+
+// POST /:id/providers/:providerId/smoke-test — verify provider connectivity
+aiModelsRoutes.post("/:id/providers/:providerId/smoke-test", async (c) => {
+  const prisma = c.get("prisma") as any;
+  const modelId = c.req.param("id");
+  const providerId = c.req.param("providerId");
+
+  const providerRow = await prisma.aiModelProvider.findUnique({
+    where: { id: providerId },
+    include: { model: { select: { stage: true, modelId: true } } },
+  });
+
+  if (!providerRow || providerRow.aiModelId !== modelId) {
+    return c.json({ error: "Provider not found" }, 404);
+  }
+
+  const result = await runSmokeTest(
+    providerRow.model.stage,
+    providerRow.provider,
+    providerRow.providerModelId ?? providerRow.model.modelId,
+    c.env
+  );
+
+  return c.json({ data: result });
 });
 
 // DELETE /:id/providers/:providerId — remove a provider


### PR DESCRIPTION
## Summary
- Adds smoke test utility to validate AI model configurations via lightweight API calls
- New admin route endpoint to trigger smoke tests from the model registry
- Frontend button in model table for on-demand testing
- 6 unit tests covering success, failure, and edge cases

## Related
- POD-34: Model Smoke Test (parent feature)
- POD-37: QA passed
- POD-38: This release

## Test plan
- [x] Unit tests pass (6/6)
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] CI pipeline passes
- [ ] Staging deploy + verify
- [ ] Production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>