### PR TITLE
fix(ios): pre-cache audio works on Capacitor (issue #8)

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -26,12 +26,7 @@ const config: CapacitorConfig = {
   ios: {
     contentInset: "automatic",
     scheme: "https",
-    // TEMPORARY: unconditionally enable inspection so we can debug iOS
-    // audio playback (issue #8) on a prod-pointing build. The npm
-    // build:ios:production script sets BLIPP_TARGET_ENV=production, which
-    // would otherwise strip this flag. REVERT before merging — production
-    // builds shipped to App Store users should not be inspectable.
-    webContentsDebuggingEnabled: true,
+    webContentsDebuggingEnabled: process.env.BLIPP_TARGET_ENV !== "production",
   },
   server: {
     hostname,

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
         .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
+        .package(name: "CapacitorNetwork", path: "../../../node_modules/@capacitor/network"),
         .package(name: "CapgoCapacitorSocialLogin", path: "../../../node_modules/@capgo/capacitor-social-login"),
         .package(name: "RevenuecatPurchasesCapacitor", path: "../../../node_modules/@revenuecat/purchases-capacitor")
     ],
@@ -27,6 +28,7 @@ let package = Package(
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
+                .product(name: "CapacitorNetwork", package: "CapacitorNetwork"),
                 .product(name: "CapgoCapacitorSocialLogin", package: "CapgoCapacitorSocialLogin"),
                 .product(name: "RevenuecatPurchasesCapacitor", package: "RevenuecatPurchasesCapacitor")
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/core": "^8.2.0",
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/ios": "^8.2.0",
+        "@capacitor/network": "^8.0.1",
         "@capgo/capacitor-social-login": "^8.3.9",
         "@clerk/backend": "^2.32.2",
         "@clerk/clerk-react": "^5.61.2",
@@ -1874,6 +1875,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/synapse": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@capacitor/core": "^8.2.0",
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/ios": "^8.2.0",
+    "@capacitor/network": "^8.0.1",
     "@capgo/capacitor-social-login": "^8.3.9",
     "@clerk/backend": "^2.32.2",
     "@clerk/clerk-react": "^5.61.2",

--- a/src/__tests__/network-tier.test.ts
+++ b/src/__tests__/network-tier.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getNetworkTier } from "../lib/network-tier";
 
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false },
+}));
+
 const realNavigator = globalThis.navigator;
 
 function setNavigator(patch: Partial<Navigator> & { connection?: any }) {
@@ -17,33 +21,33 @@ describe("getNetworkTier", () => {
     vi.useRealTimers();
   });
 
-  it("returns 'offline' when navigator.onLine is false", () => {
+  it("returns 'offline' when navigator.onLine is false", async () => {
     setNavigator({ onLine: false });
-    expect(getNetworkTier()).toBe("offline");
+    expect(await getNetworkTier()).toBe("offline");
   });
 
-  it("returns 'wifi' when connection.type is 'wifi'", () => {
+  it("returns 'wifi' when connection.type is 'wifi'", async () => {
     setNavigator({ onLine: true, connection: { type: "wifi", effectiveType: "4g" } });
-    expect(getNetworkTier()).toBe("wifi");
+    expect(await getNetworkTier()).toBe("wifi");
   });
 
-  it("returns 'cellular' when connection.type is 'cellular'", () => {
+  it("returns 'cellular' when connection.type is 'cellular'", async () => {
     setNavigator({ onLine: true, connection: { type: "cellular", effectiveType: "4g" } });
-    expect(getNetworkTier()).toBe("cellular");
+    expect(await getNetworkTier()).toBe("cellular");
   });
 
-  it("treats effectiveType '4g' as wifi-tier when connection.type missing", () => {
+  it("treats effectiveType '4g' as wifi-tier when connection.type missing", async () => {
     setNavigator({ onLine: true, connection: { effectiveType: "4g" } });
-    expect(getNetworkTier()).toBe("wifi");
+    expect(await getNetworkTier()).toBe("wifi");
   });
 
-  it("treats effectiveType '3g' as cellular-tier when connection.type missing", () => {
+  it("treats effectiveType '3g' as cellular-tier when connection.type missing", async () => {
     setNavigator({ onLine: true, connection: { effectiveType: "3g" } });
-    expect(getNetworkTier()).toBe("cellular");
+    expect(await getNetworkTier()).toBe("cellular");
   });
 
-  it("falls back to 'cellular' (conservative) when Connection API is unavailable", () => {
+  it("falls back to 'cellular' (conservative) when Connection API is unavailable", async () => {
     setNavigator({ onLine: true });
-    expect(getNetworkTier()).toBe("cellular");
+    expect(await getNetworkTier()).toBe("cellular");
   });
 });

--- a/src/__tests__/prefetcher.test.ts
+++ b/src/__tests__/prefetcher.test.ts
@@ -8,7 +8,7 @@ vi.mock("@capacitor/core", () => ({
 }));
 
 vi.mock("../lib/network-tier", () => ({
-  getNetworkTier: vi.fn(() => "wifi"),
+  getNetworkTier: vi.fn(async () => "wifi"),
 }));
 
 // In-memory Cache API polyfill for jsdom
@@ -76,7 +76,7 @@ describe("Prefetcher.scheduleFromFeed", () => {
     manager = await makeManager();
     prefetcher = new Prefetcher(manager, { cellularEnabled: false });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("wifi");
+    (getNetworkTier as any).mockResolvedValue("wifi");
     globalThis.fetch = vi.fn();
   });
 
@@ -105,7 +105,7 @@ describe("Prefetcher.scheduleFromFeed", () => {
 
   it("takes only first 2 on cellular when cellular not enabled in settings", async () => {
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("cellular");
+    (getNetworkTier as any).mockResolvedValue("cellular");
     const items = Array.from({ length: 15 }, (_, i) => makeFeedItem(`br_${i}`));
     await prefetcher.scheduleFromFeed(items);
     expect(prefetcher.queueSize()).toBe(0); // cellular off → no prefetch
@@ -115,7 +115,7 @@ describe("Prefetcher.scheduleFromFeed", () => {
     prefetcher.dispose();
     prefetcher = new Prefetcher(manager, { cellularEnabled: true });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("cellular");
+    (getNetworkTier as any).mockResolvedValue("cellular");
     const items = Array.from({ length: 15 }, (_, i) => makeFeedItem(`br_${i}`));
     await prefetcher.scheduleFromFeed(items);
     expect(prefetcher.queueSize()).toBe(2);
@@ -123,7 +123,7 @@ describe("Prefetcher.scheduleFromFeed", () => {
 
   it("takes nothing when offline", async () => {
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("offline");
+    (getNetworkTier as any).mockResolvedValue("offline");
     await prefetcher.scheduleFromFeed([makeFeedItem("br_a")]);
     expect(prefetcher.queueSize()).toBe(0);
   });
@@ -137,7 +137,7 @@ describe("Prefetcher worker loop (single concurrency)", () => {
     manager = await makeManager();
     prefetcher = new Prefetcher(manager, { cellularEnabled: false });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("wifi");
+    (getNetworkTier as any).mockResolvedValue("wifi");
     globalThis.fetch = vi.fn(async (url: any) => {
       const u = String(url);
       if (u.includes("/audio-url")) {
@@ -221,7 +221,7 @@ describe("Prefetcher.scheduleNextInQueue", () => {
     manager = await makeManager();
     prefetcher = new Prefetcher(manager, { cellularEnabled: true });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("wifi");
+    (getNetworkTier as any).mockResolvedValue("wifi");
     globalThis.fetch = vi.fn(async (url: any) => {
       const u = String(url);
       if (u.includes("/audio-url")) {
@@ -287,7 +287,7 @@ describe("Prefetcher pause/resume", () => {
     manager = await makeManager();
     prefetcher = new Prefetcher(manager, { cellularEnabled: true });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("wifi");
+    (getNetworkTier as any).mockResolvedValue("wifi");
     globalThis.fetch = vi.fn(async (url: any) => {
       const u = String(url);
       if (u.includes("/audio-url")) {
@@ -340,7 +340,7 @@ describe("Prefetcher.cancelInflight", () => {
     manager = await makeManager();
     prefetcher = new Prefetcher(manager, { cellularEnabled: true });
     const { getNetworkTier } = await import("../lib/network-tier");
-    (getNetworkTier as any).mockReturnValue("wifi");
+    (getNetworkTier as any).mockResolvedValue("wifi");
   });
 
   afterEach(() => {

--- a/src/lib/network-tier.ts
+++ b/src/lib/network-tier.ts
@@ -1,3 +1,6 @@
+import { Capacitor } from "@capacitor/core";
+import { Network } from "@capacitor/network";
+
 export type NetworkTier = "wifi" | "cellular" | "offline";
 
 interface NetworkInformationLike {
@@ -11,13 +14,22 @@ interface NavigatorWithConnection extends Navigator {
   webkitConnection?: NetworkInformationLike;
 }
 
-export function getNetworkTier(): NetworkTier {
+export async function getNetworkTier(): Promise<NetworkTier> {
+  if (Capacitor.isNativePlatform()) {
+    const status = await Network.getStatus();
+    if (!status.connected) return "offline";
+    if (status.connectionType === "wifi") return "wifi";
+    if (status.connectionType === "cellular") return "cellular";
+    // ethernet / unknown — treat as wifi-class
+    return "wifi";
+  }
+
   if (typeof navigator === "undefined") return "cellular";
   const nav = navigator as NavigatorWithConnection;
   if (nav.onLine === false) return "offline";
 
   const conn = nav.connection ?? nav.mozConnection ?? nav.webkitConnection;
-  if (!conn) return "cellular"; // conservative default (e.g., iOS Safari/WebKit)
+  if (!conn) return "cellular"; // conservative default for browsers without the API
 
   if (conn.type === "wifi" || conn.type === "ethernet") return "wifi";
   if (conn.type === "cellular") return "cellular";

--- a/src/services/prefetcher.ts
+++ b/src/services/prefetcher.ts
@@ -83,7 +83,7 @@ export class Prefetcher {
 
   async scheduleFromFeed(items: FeedItemLike[]): Promise<void> {
     if (this.disposed) return;
-    const tier = getNetworkTier();
+    const tier = await getNetworkTier();
     const take = this.takeForTier(tier);
     if (take === 0) return;
 
@@ -176,12 +176,18 @@ export class Prefetcher {
       if (!urlRes.ok) return;
       const body = (await urlRes.json()) as { url: string };
 
-      const audioRes = await fetch(body.url, { signal: this.currentAbort.signal });
+      // body.url is server-relative; prepend getApiBase() so native fetches
+      // hit the real backend instead of resolving against the local bundle.
+      const audioRes = await fetch(`${getApiBase()}${body.url}`, { signal: this.currentAbort.signal });
       if (!audioRes.ok) return;
       const blob = await audioRes.blob();
       await this.manager.store(briefingId, blob);
-    } catch {
-      // Silent. Next feed event will re-enqueue.
+    } catch (err) {
+      // Non-fatal — next feed event will re-enqueue. Log so prefetch
+      // failures don't go entirely silent in dev.
+      if ((err as any)?.name !== "AbortError") {
+        console.warn("[prefetch] fetchAndStore failed", briefingId, err);
+      }
     } finally {
       this.currentAbort = null;
       this.currentBriefingId = null;

--- a/src/services/storage-manager.ts
+++ b/src/services/storage-manager.ts
@@ -107,16 +107,30 @@ function idbClear(db: IDBDatabase, store: string): Promise<void> {
 
 const isNative = Capacitor.isNativePlatform();
 
+// Convert a Blob to base64 without spreading every byte through the call
+// stack. String.fromCharCode(...arr) blows up RangeError on multi-MB audio
+// blobs in iOS WKWebView; FileReader handles any size.
+async function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const idx = dataUrl.indexOf(",");
+      resolve(idx >= 0 ? dataUrl.slice(idx + 1) : dataUrl);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
 async function writeBlob(briefingId: string, blob: Blob): Promise<void> {
   if (isNative) {
-    const buffer = await blob.arrayBuffer();
-    const base64 = btoa(
-      String.fromCharCode(...new Uint8Array(buffer)),
-    );
+    const base64 = await blobToBase64(blob);
     await Filesystem.writeFile({
       path: `${CACHE_DIR}/${briefingId}.audio`,
       data: base64,
       directory: Directory.Data,
+      recursive: true,
     });
   } else {
     const cache = await caches.open(DB_NAME);
@@ -286,7 +300,10 @@ export class StorageManager {
       throw new Error(`audio-url fetch failed: ${res.status}`);
     }
     const body = (await res.json()) as { url: string; expiresAt: number };
-    return body.url;
+    // body.url is a server-relative path. On native the WebView origin is
+    // capacitor:// (local bundle), so it must be made absolute against the
+    // real backend or the audio element fetches the SPA shell instead.
+    return `${getApiBase()}${body.url}`;
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #8.

iOS Capacitor builds played the intro jingle then went silent, briefings never landed in the IndexedDB manifest, and tapping a feed item always made a fresh network round-trip. Multiple bugs all hidden behind a silent catch in the prefetcher.

- `network-tier`: `getNetworkTier()` now uses `@capacitor/network` on native (WKWebView doesn't expose the Web Network Information API; old code fell through to `"cellular"` and refused to prefetch). Function is now async.
- `storage-manager.writeBlob`: replaced `btoa(String.fromCharCode(...arr))` with `FileReader.readAsDataURL` — the spread blew up `RangeError` on multi-MB blobs in JavaScriptCore.
- `Filesystem.writeFile`: `recursive: true` so `blipp-cache/` is created on first write.
- `storage-manager.getPlayableUrl` + `prefetcher.fetchAndStore`: prepend `getApiBase()` to `body.url` so audio fetches hit the real backend instead of resolving against `capacitor://` (the local bundle origin, which served the SPA shell as fake audio).
- `prefetcher`: `console.warn` on fetch/store failure (was empty catch — masked all of the above for a long time).
- Backend `/api/briefings/:id/audio-url` (already shipped in 8199bd1): authorize via FeedItem ownership rather than Briefing ownership; sign the audio token with the briefing's owner so `/audio` verification still works.
- Cleanup: revert temporary `webContentsDebuggingEnabled: true` from 8a55b9f back to env-conditional.

## Test plan

- [x] `npx vitest run src/__tests__/network-tier.test.ts src/__tests__/prefetcher.test.ts src/__tests__/storage-manager.test.ts worker/routes/__tests__/briefings-audio-url.test.ts` — passes locally
- [x] Manual on iOS Simulator (production build): tap feed item → intro → full briefing → outro
- [x] IndexedDB `blipp-storage/blipp-manifest` populates within ~30s of feed load
- [x] Tap a cached briefing → no `/audio-url` or `/audio` network requests; instant playback after intro
- [ ] Verify cellular gating on a real device or via the Settings toggle (covered by unit tests; runtime manual check optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)